### PR TITLE
Add support for accessing the RunnerCommand.CommandData, optionally.

### DIFF
--- a/RvtTestRunner.sln
+++ b/RvtTestRunner.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3202678B-EECF-46E3-9631-C026CAE9D62B}"
 EndProject
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		SharedCodeAnalysis.ruleset = SharedCodeAnalysis.ruleset
+		TestClassRuleSet.ruleset = TestClassRuleSet.ruleset
 	EndProjectSection
 EndProject
 Global

--- a/TestClassRuleSet.ruleset
+++ b/TestClassRuleSet.ruleset
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Test Class Rule Set" Description=" Rule Set for Test Classes of SampleRevitApp. Child of SharedCodeAnalysis" ToolsVersion="15.0">
+  <Include Path="..\..\..\..\source\repos\rvttestrunner\sharedcodeanalysis.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS1591" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1707" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1600" Action="None" />
+  </Rules>
+</RuleSet>

--- a/src/RvtTestRunner/Runner/RvtRunner.cs
+++ b/src/RvtTestRunner/Runner/RvtRunner.cs
@@ -140,6 +140,13 @@ namespace RvtTestRunner.Runner
                 executionOptions.SetDisableParallelization(!parallelizeTestCollections.GetValueOrDefault());
             }
 
+            var longRunningSeconds = options.LongRunningSeconds;
+
+            if (longRunningSeconds.HasValue)
+            {
+                assembly.Configuration.LongRunningTestSeconds = longRunningSeconds.Value;
+            }
+
             return executionOptions;
         }
 

--- a/src/RvtTestRunner/Runner/TestRunner.cs
+++ b/src/RvtTestRunner/Runner/TestRunner.cs
@@ -5,7 +5,6 @@
 namespace RvtTestRunner.Runner
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     using JetBrains.Annotations;
@@ -30,13 +29,13 @@ namespace RvtTestRunner.Runner
         /// <summary>
         ///     Runs all tests contained in the given assemblies (config is not handled yet)
         /// </summary>
-        /// <param name="assemblies">The paths for assemblies containing tests to be run</param>
+        /// <param name="options">The test run options</param>
         /// <returns>The number of failed tests, or -1 if cancelled</returns>
-        public int Run([NotNull] List<(string AssemblyFileName, string ConfigFile)> assemblies)
+        public int Run([NotNull] TestRunOptions options)
         {
-            if (assemblies == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(assemblies));
+                throw new ArgumentNullException(nameof(options));
             }
 
             using (AssemblyHelper.SubscribeResolve())
@@ -52,10 +51,6 @@ namespace RvtTestRunner.Runner
                 }
 
                 var reporter = result ?? new DefaultRunnerReporterWithTypes();*/
-
-                var reporter = new DefaultRunnerReporterWithTypes();
-
-                var options = new TestRunOptions(assemblies, reporter);
 
                 try
                 {

--- a/src/RvtTestRunner/UI/TestRunnerControl.xaml
+++ b/src/RvtTestRunner/UI/TestRunnerControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="RvtTestRunner.UI.TestRunnerControl"
+<UserControl x:Class="RvtTestRunner.UI.TestRunnerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -11,13 +11,18 @@
         <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
             <Setter Property="Width" Value="75" />
             <Setter Property="Height" Value="25" />
-            <Setter Property="Margin" Value="5"></Setter>
+            <Setter Property="Margin" Value="5" />
+        </Style>
+        <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+            <Setter Property="Margin" Value="5" />
         </Style>
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -28,11 +33,13 @@
         <Label Target="{Binding ElementName=SelectedAssemblies}" Content="Selected Assemblies" />
         <ListBox Name="SelectedAssemblies" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
                  ItemsSource="{Binding Path=SelectedAssemblies}" SelectedItem="{Binding Path=SelectedAssembly}" />
-        <Button Grid.Row="2" Grid.Column="0" Content="Add" Command="{Binding Path=BrowseCommand}" />
-        <Button Grid.Row="2" Grid.Column="1" Content="Remove" Command="{Binding Path=RemoveCommand}" />
-        <Button Grid.Row="3" Grid.Column="0" Content="Execute" Command="{Binding Path=ExecuteCommand}"
+        <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Content="Allow ExternalCommandData Access" IsChecked="{Binding Path=AllowCommandDataAccess}" />
+        <CheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="Copy DLLs to new folder" IsChecked="{Binding Path=CopyDllsToNewFolder}" IsEnabled="{Binding Path=IsCopyDllsToNewFolderEnabled}" />
+        <Button Grid.Row="4" Grid.Column="0" Content="Add" Command="{Binding Path=BrowseCommand}" />
+        <Button Grid.Row="4" Grid.Column="1" Content="Remove" Command="{Binding Path=RemoveCommand}" />
+        <Button Grid.Row="5" Grid.Column="0" Content="Execute" Command="{Binding Path=ExecuteCommand}"
                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
-        <Button Grid.Row="3" Grid.Column="1" Content="Cancel" Command="{Binding Path=CancelCommand}"
+        <Button Grid.Row="5" Grid.Column="1" Content="Cancel" Command="{Binding Path=CancelCommand}"
                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
     </Grid>
 </UserControl>

--- a/test/RvtTestRunner.Test/RvtTestRunner.Test.csproj
+++ b/test/RvtTestRunner.Test/RvtTestRunner.Test.csproj
@@ -59,6 +59,7 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <LangVersion>7.1</LangVersion>
+    <CodeAnalysisRuleSet>..\..\TestClassRuleSet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == '2018|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -256,6 +257,7 @@
       <Link>stylecop.json</Link>
     </AdditionalFiles>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UI\TestRunnerControlViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac">
@@ -285,6 +287,9 @@
     <PackageReference Include="reactiveui">
       <Version>8.0.0-alpha0117</Version>
     </PackageReference>
+    <PackageReference Include="ReactiveUI.Testing">
+      <Version>8.0.0-alpha0117</Version>
+    </PackageReference>
     <PackageReference Include="ReactiveUI.WPF">
       <Version>8.0.0-alpha0117</Version>
     </PackageReference>
@@ -301,6 +306,11 @@
       <Version>2.3.1</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RvtTestRunner\RvtTestRunner.csproj">
+      <Project>{9d680c27-e296-4024-9399-8ef8f2a9522d}</Project>
+      <Name>RvtTestRunner</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/RvtTestRunner.Test/UI/TestRunnerControlViewModelTests.cs
+++ b/test/RvtTestRunner.Test/UI/TestRunnerControlViewModelTests.cs
@@ -1,0 +1,60 @@
+// <copyright file="TestRunnerControlViewModelTests.cs" company="StarkBIM Inc">
+// Copyright (c) StarkBIM Inc. All rights reserved.
+// </copyright>
+
+namespace RvtTestRunner.Test.UI
+{
+    using System.Reactive.Concurrency;
+
+    using JetBrains.Annotations;
+
+    using RvtTestRunner.UI;
+
+    using Xunit;
+
+    public class TestRunnerControlViewModelTests
+    {
+        [Fact]
+        public void DefaultValues_Accurate()
+        {
+            var testRunnerControlViewModel = Build();
+
+            Assert.False(testRunnerControlViewModel.AllowCommandDataAccess);
+            Assert.False(testRunnerControlViewModel.IsCopyDllsToNewFolderEnabled);
+            Assert.False(testRunnerControlViewModel.CopyDllsToNewFolder);
+        }
+
+        [Fact]
+        public void IsCopyDllsToNewFolderEnabled_Matches_AllowCommandDataAccess()
+        {
+            var testRunnerControlViewModel = Build();
+            testRunnerControlViewModel.AllowCommandDataAccess = true;
+
+            Assert.True(testRunnerControlViewModel.AllowCommandDataAccess);
+            Assert.True(testRunnerControlViewModel.IsCopyDllsToNewFolderEnabled);
+
+            testRunnerControlViewModel.AllowCommandDataAccess = false;
+
+            Assert.False(testRunnerControlViewModel.AllowCommandDataAccess);
+            Assert.False(testRunnerControlViewModel.IsCopyDllsToNewFolderEnabled);
+        }
+
+        [Fact]
+        public void IsCopyDllsToNewFolder_False_When_Disabled()
+        {
+            var testRunnerControlViewModel = Build();
+            testRunnerControlViewModel.AllowCommandDataAccess = true;
+            testRunnerControlViewModel.CopyDllsToNewFolder = true;
+
+            Assert.True(testRunnerControlViewModel.CopyDllsToNewFolder);
+
+            testRunnerControlViewModel.AllowCommandDataAccess = false;
+
+            Assert.False(testRunnerControlViewModel.AllowCommandDataAccess);
+            Assert.False(testRunnerControlViewModel.CopyDllsToNewFolder);
+        }
+
+        [NotNull]
+        private static TestRunnerControlViewModel Build() => new TestRunnerControlViewModel(Scheduler.Immediate);
+    }
+}


### PR DESCRIPTION
Add support for accessing the RunnerCommand.CommandData, optionally. It is optional because it disables parallel test execution.

Because this also involves disabling individual AppDomains per test run, add the ability to copy DLLs to a new folder for each test run.  This allows the DLLs to be modified, recompiled, and retested without closing Revit.
 
Closes #2 